### PR TITLE
Use HTTPS for demo so it will work on newer Chrome

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ Say Cheese!
 A minimal library for integrating webcam snapshots into your app. It uses `getUserMedia`, a recent API for
 accessing audio and video in the browser.
 
-[**Demo**](http://leemachin.github.com/say-cheese)
+[**Demo**](https://leemachin.github.com/say-cheese)
 
 Setup
 -----


### PR DESCRIPTION
Newer Chrome browsers don't allow video over HTTP. Just linking to the HTTPS version of the GitHub page should fix it.
