### PR TITLE
Use srcObject

### DIFF
--- a/say-cheese.js
+++ b/say-cheese.js
@@ -153,11 +153,17 @@ var SayCheese = (function() {
             this.stream = stream;
             this.createVideo();
 
-            if (navigator.mozGetUserMedia) {
-                this.video.mozSrcObject = stream;
-            } else {
-                this.video.src = this.getStreamUrl();
+            // https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject
+            try {
+                this.video.srcObject = stream;
+            } catch (e) {
+                if (navigator.mozGetUserMedia) {
+                    this.video.mozSrcObject = stream;
+                } else {
+                    this.video.src = this.getStreamUrl();
+                }
             }
+
 
             if (this.options.audio === true) {
                 try {


### PR DESCRIPTION
Trying to window.URL.createObjectURL(stream) on Safari 11 throws TypeError. This pull request introduces srcObject solution for setting stream, and when it fails try previous methods
Links:
https://github.com/Kurento/bugtracker/issues/186
https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject